### PR TITLE
Align docs with framework v1.2.8 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Documentation and website for Vanduo, served at https://vanduo.dev.
 Framework repo: https://github.com/vanduo-oss/framework
 NPM Package: https://www.npmjs.com/package/@vanduo-oss/framework
 
+## Current Snapshot
+
+- Docs are aligned with the v1.2.8 release surface.
+- The live docs shell now loads the pinned framework CDN bundle from `@v1.2.8` instead of the locally vendored `dist/` copy.
+- Theme tooling is documented as two separate components: Theme Switcher for lightweight system/light/dark toggles and Theme Customizer for full palette, neutral, radius, and font control.
+- The docs UI and release-facing copy were refreshed during the v1.2.8 pre-release pass.
+
 ## Installation
 
 **We strongly recommend using [pnpm](https://pnpm.io/)**. The Vanduo ecosystem uses strict `.npmrc` security policies for dependency isolation and lockfile enforcement.
@@ -16,3 +23,9 @@ pnpm add @vanduo-oss/framework
 ## Local preview
 
 Open index.html directly or run a simple static server.
+
+## Validation
+
+```bash
+pnpm test
+```

--- a/css/app.css
+++ b/css/app.css
@@ -115,13 +115,13 @@
 
         /* ── Docs layout ────────────────────────────────── */
         section {
-            padding: 4rem 0;
-            scroll-margin-top: calc(70px + var(--doc-tabs-height, 0px) + 2rem);
-            border-bottom: 1px solid var(--border-color);
+            padding: 2rem 0;
+            scroll-margin-top: calc(70px + var(--doc-tabs-height, 0px) + 0.5rem);
+            border-bottom: none;
         }
 
         section:first-of-type {
-            padding-top: 2rem;
+            padding-top: 1rem;
         }
 
         section:last-of-type {
@@ -138,8 +138,8 @@
             align-items: center;
             gap: 0.5rem;
             margin-bottom: 1.5rem;
-            padding-bottom: 0.75rem;
-            border-bottom: 2px solid var(--color-primary);
+            padding-bottom: 0;
+            border-bottom: none;
             font-size: 1.75rem;
             color: var(--color-primary);
         }
@@ -375,7 +375,7 @@
             top: 70px;
             height: calc(100vh - 80px);
             overflow: visible;
-            padding-right: 1rem;
+            padding-right: 0.5rem;
             border-right: 1px solid var(--border-color);
             display: flex;
             flex-direction: column;
@@ -1157,6 +1157,11 @@
             display: block;
         }
 
+        /* Full-width docs container — remove max-width constraint */
+        #docs-view .vd-container-responsive {
+            max-width: none;
+        }
+
         /* ── Sticky doc-tabs on desktop & tablet ──────── */
         .doc-tabs-wrapper {
             display: flex;
@@ -1180,7 +1185,6 @@
                 background: var(--bg-primary);
                 padding: 0.75rem 0;
                 margin: 0;
-                border-bottom: 1px solid var(--border-color);
                 flex-wrap: wrap;
             }
 
@@ -1214,7 +1218,6 @@
                 background: var(--bg-primary);
                 padding: 1rem 0 0.75rem;
                 margin: 0;
-                border-bottom: 1px solid var(--border-color);
             }
 
             .doc-tabs {

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
                 </div>
 
                 <div class="vd-row">
-                    <aside class="vd-col-12 vd-col-lg-3 doc-sidebar">
+                    <aside class="vd-col-12 vd-col-lg-2 doc-sidebar">
 
                         <button class="doc-sidebar-toggle" aria-label="Toggle navigation" aria-expanded="false">Table of
                             Contents</button>
@@ -134,7 +134,7 @@
                         </nav>
                     </aside>
 
-                    <div class="vd-col-12 vd-col-lg-9 doc-content" id="dynamic-content"></div>
+                    <div class="vd-col-12 vd-col-lg-10 doc-content" id="dynamic-content"></div>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
-        content="Vanduo Framework v1.2.7. Pure HTML, CSS, JS framework for beautiful websites. Zero runtime dependencies, no mandatory build tools, just clean code.">
+        content="Vanduo Framework v1.2.8. Pure HTML, CSS, JS framework for beautiful websites. Zero runtime dependencies, no mandatory build tools, just clean code.">
     <meta name="author" content="Vanduo Framework">
     <meta name="keywords"
         content="CSS framework, HTML framework, JavaScript framework, static website, no dependencies, pure CSS, pure JavaScript, responsive design, UI components, Lithuania">
@@ -18,7 +18,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://vanduo.dev/">
-    <meta property="og:title" content="Vanduo Framework v1.2.7 - Pure HTML, CSS, JS Framework">
+    <meta property="og:title" content="Vanduo Framework v1.2.8 - Pure HTML, CSS, JS Framework">
     <meta property="og:description"
         content="Essential just like water is. Zero-dependency framework for beautiful static websites.">
     <meta property="og:image" content="https://vanduo.dev/images/og-image.png">
@@ -28,7 +28,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://vanduo.dev/">
-    <meta name="twitter:title" content="Vanduo Framework v1.2.7 - Pure HTML, CSS, JS Framework">
+    <meta name="twitter:title" content="Vanduo Framework v1.2.8 - Pure HTML, CSS, JS Framework">
     <meta name="twitter:description"
         content="Essential just like water is. Zero-dependency framework for beautiful static websites.">
     <meta name="twitter:image" content="https://vanduo.dev/images/twitter-card.png">
@@ -36,8 +36,8 @@
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="./favicon.svg">
 
-    <!-- Vanduo Framework CSS (local dist for manual verification) -->
-    <link rel="stylesheet" href="dist/vanduo.min.css">
+    <!-- Vanduo Framework CSS (pinned CDN release) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/vanduo-oss/framework@v1.2.8/dist/vanduo.min.css">
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
@@ -59,7 +59,7 @@
         "price": "0",
         "priceCurrency": "USD"
       },
-      "softwareVersion": "1.2.2",
+    "softwareVersion": "1.2.8",
       "license": "https://opensource.org/licenses/MIT",
       "programmingLanguage": ["HTML", "CSS", "JavaScript"]
     }
@@ -207,8 +207,8 @@
         </div>
     </div>
 
-    <!-- ── Vanduo Framework JS (local dist for manual verification) ─────────────────── -->
-    <script src="dist/vanduo.min.js"></script>
+    <!-- ── Vanduo Framework JS (pinned CDN release) ─────────────────── -->
+    <script src="https://cdn.jsdelivr.net/gh/vanduo-oss/framework@v1.2.8/dist/vanduo.min.js"></script>
 
     <!-- ── SPA Engine ─────────────────────────────────── -->
     <script src="js/lazy-loader.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -11,10 +11,10 @@ if (typeof window.Vanduo === 'undefined') {
         });
         Object.assign(window.ThemeCustomizer.DEFAULTS, {
             FONT: 'lato',
-            PRIMARY_LIGHT: 'cyan',
-            PRIMARY_DARK: 'cyan',
-            NEUTRAL: 'stone',
-            RADIUS: '0.375'
+            PRIMARY_LIGHT: 'black',
+            PRIMARY_DARK: 'amber',
+            NEUTRAL: 'slate',
+            RADIUS: '0.25'
         });
     }
     window.Vanduo.init();

--- a/llms.txt
+++ b/llms.txt
@@ -2,6 +2,8 @@
 > Pure HTML, CSS, JS framework for designing beautiful websites.
 > Zero runtime dependencies, no mandatory build tools, just clean and simple code.
 > MIT Licensed. https://vanduo.dev
+> Current docs snapshot is aligned with framework v1.2.8.
+> The live docs shell loads the pinned framework CDN bundle from @v1.2.8.
 
 ## What is Vanduo?
 Vanduo is a lightweight front-end framework built on plain HTML, CSS, and JavaScript.
@@ -12,12 +14,20 @@ frameworks.
 ## Key Features
 - Fibonacci/Golden Ratio design system for spacing, typography, and grid
 - Modular CSS — use the full bundle or pick individual components
-- Built-in dark mode with light/dark/system preference (localStorage)
-- Theme customizer: primary color, neutral, radius, font family
+- Built-in theme tools: Theme Switcher for light/dark/system preference and Theme Customizer for primary color, neutral, radius, and font family control
+- Dedicated documentation for Theme Switcher, Theme Customizer, and their shared coordination model
 - 1,500+ Phosphor Icons in 6 weights, bundled locally (no CDN required)
 - Open Color palette (10-step accessible color scales)
 - Accessibility-first: ARIA, focus-visible, reduced-motion, semantic HTML
 - Lazy loading, parallax, tabs, toasts, draggable, search, and more
+
+## Docs Runtime Overrides
+Before `Vanduo.init()`, the docs site overrides framework Theme Customizer defaults to:
+- Font: `lato`
+- Primary light: `black`
+- Primary dark: `amber`
+- Neutral: `slate`
+- Radius: `0.25`
 
 ## Documentation Structure
 The docs site is a single-page application (SPA) at https://vanduo.dev.
@@ -26,7 +36,10 @@ All content is hash-routed. Main sections:
 - #home            — Overview, features, icon preview, color palette
 - #docs            — Full component and concept documentation
 - #docs/components — UI components (buttons, cards, forms, alerts, etc.)
+- #docs/theme-switcher   — Lightweight light/dark/system toggle component
+- #docs/theme-customizer — Full runtime theming panel component
 - #docs/guides     — Getting started, lazy loading, theme customizer, ESM vs IIFE
+- #docs/theme-customizer-guide — Setup and coordination walkthrough for the theming panel
 - #docs/concepts   — Design philosophy, tokens, namespacing, lifecycle, modules
 - #changelog       — Version history
 - #about           — Project background

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanduo-docs",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "private": true,
   "description": "Vanduo documentation and website",
   "scripts": {

--- a/sections/changelog.html
+++ b/sections/changelog.html
@@ -15,6 +15,83 @@
         <div class="vd-container-responsive" style="max-width: 1200px;">
 
             <!-- ═══════════════════════════════════════════════ -->
+            <!-- Version 1.2.8                                   -->
+            <!-- ═══════════════════════════════════════════════ -->
+            <article class="version-card">
+                <header class="version-header">
+                    <span class="vd-badge vd-badge-primary" style="font-size: 1rem; padding: 0.5rem 1rem;">v1.2.8</span>
+                    <span style="color: var(--text-secondary); font-size: 0.95rem;">
+                        <i class="ph ph-calendar mr-1"></i>March 14, 2026
+                    </span>
+                    <span class="vd-badge vd-badge-info" style="font-size: 0.75rem;">Latest</span>
+                </header>
+                <div class="version-body">
+                    <div class="vd-row">
+                        <div class="vd-col-12 vd-col-md-6">
+                            <h4><i class="ph ph-cube mr-2" style="color: var(--color-primary);"></i>Framework</h4>
+                            <div class="change-group">
+                                <h5>Improvements</h5>
+                                <ul class="change-list">
+                                    <li class="change-item">
+                                        <i class="ph ph-arrow-up" style="color: var(--color-info);"></i>
+                                        <div>
+                                            <strong>Improvement: Theme Switcher and Theme Customizer now coordinate state</strong>
+                                            <p>Theme changes now flow through the shared
+                                                <code>vanduo-theme-preference</code> key, prevent circular updates,
+                                                and only swap between <code>PRIMARY_LIGHT</code> and
+                                                <code>PRIMARY_DARK</code> while the user is still using the default
+                                                per-theme primary color.</p>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="vd-col-12 vd-col-md-6">
+                            <h4><i class="ph ph-book-open-text mr-2"
+                                    style="color: var(--color-primary);"></i>Documentation</h4>
+                            <div class="change-group">
+                                <h5>New Features</h5>
+                                <ul class="change-list">
+                                    <li class="change-item">
+                                        <i class="ph ph-sparkle" style="color: var(--color-primary);"></i>
+                                        <div>
+                                            <strong>New: Separate Theme Switcher and Theme Customizer component docs</strong>
+                                            <p>Theme tooling is now documented as two distinct components. Theme
+                                                Switcher covers lightweight system/light/dark toggles, while Theme
+                                                Customizer focuses on full palette, neutral, radius, font, and mode
+                                                control.</p>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="change-group">
+                                <h5>Updates</h5>
+                                <ul class="change-list">
+                                    <li class="change-item">
+                                        <i class="ph ph-arrows-clockwise" style="color: var(--color-success);"></i>
+                                        <div>
+                                            <strong>Update: Theme coordination guidance added to docs</strong>
+                                            <p>The Theme Customizer page now explains how it coexists with Theme
+                                                Switcher, including shared preference storage and per-theme default
+                                                primary colors.</p>
+                                        </div>
+                                    </li>
+                                    <li class="change-item">
+                                        <i class="ph ph-arrow-up" style="color: var(--color-info);"></i>
+                                        <div>
+                                            <strong>Update: Visual docs refresh and version surfaces aligned to v1.2.8</strong>
+                                            <p>Changelog, docs landing, quick start, metadata, README, and llms
+                                                context were refreshed during the v1.2.8 pre-release pass.</p>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </article>
+
+            <!-- ═══════════════════════════════════════════════ -->
             <!-- Version 1.2.7                                   -->
             <!-- ═══════════════════════════════════════════════ -->
             <article class="version-card">
@@ -23,7 +100,6 @@
                     <span style="color: var(--text-secondary); font-size: 0.95rem;">
                         <i class="ph ph-calendar mr-1"></i>March 11, 2026
                     </span>
-                    <span class="vd-badge vd-badge-info" style="font-size: 0.75rem;">Latest</span>
                 </header>
                 <div class="version-body">
                     <div class="vd-row">

--- a/sections/components/theme-customizer.html
+++ b/sections/components/theme-customizer.html
@@ -281,6 +281,58 @@ customizer.<span class="code-function">reset</span>();</code></pre>
         </table>
     </div>
 
+    <h3 class="docs-heading">Coordination with ThemeSwitcher</h3>
+    <div class="vd-row vd-mb-8">
+        <div class="vd-col-12">
+            <div class="vd-card vd-card-glow demo-card">
+                <div class="vd-card-header">
+                    <h3>Auto-Coordination</h3>
+                </div>
+                <div class="vd-card-body">
+                    <p>When both ThemeCustomizer and ThemeSwitcher are present on the same page, they automatically stay
+                        in sync:</p>
+                    <ul class="vd-mt-4">
+                        <li>Changing theme via <strong>ThemeSwitcher</strong> button triggers primary color swap if using
+                            defaults</li>
+                        <li>Changing theme via <strong>ThemeCustomizer</strong> panel updates ThemeSwitcher state</li>
+                        <li>Preferences are shared via <code>localStorage</code></li>
+                    </ul>
+                    <div class="vd-code-snippet vd-mt-5" data-collapsible>
+                        <button class="vd-code-snippet-toggle" aria-expanded="false">
+                            <span class="vd-code-snippet-toggle-icon"></span>
+                            <span>View Code</span>
+                        </button>
+                        <div class="vd-code-snippet-content">
+                            <div class="vd-code-snippet-header">
+                                <div class="vd-code-snippet-tabs" role="tablist">
+                                    <button class="vd-code-snippet-tab is-active" data-lang="html">HTML</button>
+                                </div>
+                                <button class="vd-code-snippet-copy" aria-label="Copy code">
+                                    <span class="vd-code-snippet-copy-icon"></span>
+                                    <span class="vd-code-snippet-copy-text">Copy</span>
+                                </button>
+                            </div>
+                            <div class="vd-code-snippet-body">
+                                <pre class="vd-code-snippet-pane is-active"
+                                    data-lang="html"><code><span class="code-comment"><!-- Navbar: Quick toggle via ThemeSwitcher --></span>
+<<span class="code-tag">button</span> <span class="code-attr">class</span>=<span class="code-string">"vd-btn vd-btn-icon"</span> <span class="code-attr">data-toggle</span>=<span class="code-string">"theme"</span>>
+    <<span class="code-tag">i</span> <span class="code-attr">class</span>=<span class="code-string">"ph ph-moon"</span>></<span class="code-tag">i</span>>
+</<span class="code-tag">button</span>>
+
+<span class="code-comment"><!-- Settings: Full panel via ThemeCustomizer --></span>
+<<span class="code-tag">button</span> <span class="code-attr">class</span>=<span class="code-string">"vd-theme-customizer-trigger"</span> <span class="code-attr">data-theme-customizer-trigger</span>>
+    <<span class="code-tag">i</span> <span class="code-attr">class</span>=<span class="code-string">"ph ph-paint-roller"</span>></<span class="code-tag">i</span>>
+</<span class="code-tag">button</span>>
+
+<span class="code-comment"><!-- Both components coordinate automatically --></span></code></pre>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div class="vd-row">
         <div class="vd-col-12 vd-col-md-6">
             <div class="vd-card vd-card-glow demo-card">

--- a/sections/components/theme-switcher.html
+++ b/sections/components/theme-switcher.html
@@ -1,0 +1,367 @@
+<section id="theme-switcher">
+    <h2 class="demo-title"><i class="ph ph-moon"></i>Theme Switcher</h2>
+    <p class="vd-mb-8">The Theme Switcher is a lightweight component for toggling between light, dark, and system color
+        modes. Unlike the full Theme Customizer, it focuses solely on the color mode toggle without additional
+        customization options. Perfect for when you need a simple dark mode button.</p>
+
+    <div class="vd-alert vd-alert-info vd-mb-8">
+        <i class="ph ph-info"></i>
+        <div>
+            <strong>Coordination with ThemeCustomizer:</strong> When both components are present, they automatically
+            stay in sync. Changing the theme via ThemeSwitcher will also swap the primary color if you're using the
+            default per-theme colors (PRIMARY_LIGHT / PRIMARY_DARK).
+        </div>
+    </div>
+
+    <div class="vd-row">
+        <div class="vd-col-12 vd-col-md-6">
+            <div class="vd-card vd-card-glow demo-card">
+                <div class="vd-card-header">
+                    <h3>Button Toggle</h3>
+                </div>
+                <div class="vd-card-body">
+                    <p>Add <code>data-toggle="theme"</code> to any button to enable theme cycling:</p>
+                    <div class="vd-code-snippet" data-collapsible>
+                        <button class="vd-code-snippet-toggle" aria-expanded="false">
+                            <span class="vd-code-snippet-toggle-icon"></span>
+                            <span>View Code</span>
+                        </button>
+                        <div class="vd-code-snippet-content">
+                            <div class="vd-code-snippet-header">
+                                <div class="vd-code-snippet-tabs" role="tablist">
+                                    <button class="vd-code-snippet-tab is-active" data-lang="html">HTML</button>
+                                </div>
+                                <button class="vd-code-snippet-copy" aria-label="Copy code">
+                                    <span class="vd-code-snippet-copy-icon"></span>
+                                    <span class="vd-code-snippet-copy-text">Copy</span>
+                                </button>
+                            </div>
+                            <div class="vd-code-snippet-body">
+                                <pre class="vd-code-snippet-pane is-active"
+                                    data-lang="html"><code><span class="code-comment"><!-- Simple icon button --></span>
+<<span class="code-tag">button</span> <span class="code-attr">class</span>=<span class="code-string">"vd-btn vd-btn-icon"</span> 
+        <span class="code-attr">data-toggle</span>=<span class="code-string">"theme"</span>
+        <span class="code-attr">aria-label</span>=<span class="code-string">"Toggle theme"</span>>
+    <<span class="code-tag">i</span> <span class="code-attr">class</span>=<span class="code-string">"ph ph-moon"</span>></<span class="code-tag">i</span>>
+</<span class="code-tag">button</span>>
+
+<span class="code-comment"><!-- Button with label --></span>
+<<span class="code-tag">button</span> <span class="code-attr">class</span>=<span class="code-string">"vd-btn vd-btn-secondary"</span> 
+        <span class="code-attr">data-toggle</span>=<span class="code-string">"theme"</span>>
+    Theme: <<span class="code-tag">span</span> <span class="code-attr">class</span>=<span class="code-string">"theme-current-label"</span>>System</<span class="code-tag">span</span>>
+</<span class="code-tag">button</span>>
+
+<span class="code-comment"><!-- Include the JS component --></span>
+<<span class="code-tag">script</span> <span class="code-attr">src</span>=<span class="code-string">"js/components/theme-switcher.js"</span>></<span class="code-tag">script</span>></code></pre>
+                            </div>
+                        </div>
+                    </div>
+                    <p class="vd-mt-5"><strong>Try it:</strong> Click the theme button in the navbar to cycle through
+                        System → Light → Dark → System.</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="vd-col-12 vd-col-md-6">
+            <div class="vd-card vd-card-glow demo-card">
+                <div class="vd-card-header">
+                    <h3>Select Dropdown</h3>
+                </div>
+                <div class="vd-card-body">
+                    <p>Use a select element for explicit theme selection:</p>
+                    <div class="vd-code-snippet" data-collapsible>
+                        <button class="vd-code-snippet-toggle" aria-expanded="false">
+                            <span class="vd-code-snippet-toggle-icon"></span>
+                            <span>View Code</span>
+                        </button>
+                        <div class="vd-code-snippet-content">
+                            <div class="vd-code-snippet-header">
+                                <div class="vd-code-snippet-tabs" role="tablist">
+                                    <button class="vd-code-snippet-tab is-active" data-lang="html">HTML</button>
+                                </div>
+                                <button class="vd-code-snippet-copy" aria-label="Copy code">
+                                    <span class="vd-code-snippet-copy-icon"></span>
+                                    <span class="vd-code-snippet-copy-text">Copy</span>
+                                </button>
+                            </div>
+                            <div class="vd-code-snippet-body">
+                                <pre class="vd-code-snippet-pane is-active"
+                                    data-lang="html"><code><span class="code-comment"><!-- Select dropdown --></span>
+<<span class="code-tag">select</span> <span class="code-attr">class</span>=<span class="code-string">"vd-form-select"</span> <span class="code-attr">data-toggle</span>=<span class="code-string">"theme"</span>>
+    <<span class="code-tag">option</span> <span class="code-attr">value</span>=<span class="code-string">"system"</span>>System</<span class="code-tag">option</span>>
+    <<span class="code-tag">option</span> <span class="code-attr">value</span>=<span class="code-string">"light"</span>>Light</<span class="code-tag">option</span>>
+    <<span class="code-tag">option</span> <span class="code-attr">value</span>=<span class="code-string">"dark"</span>>Dark</<span class="code-tag">option</span>>
+</<span class="code-tag">select</span>></code></pre>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="vd-row">
+        <div class="vd-col-12 vd-col-md-6">
+            <div class="vd-card vd-card-glow demo-card">
+                <div class="vd-card-header">
+                    <h3>ThemeSwitcher vs ThemeCustomizer</h3>
+                </div>
+                <div class="vd-card-body">
+                    <div class="vd-table-responsive">
+                        <table class="vd-table vd-table-striped">
+                            <thead>
+                                <tr>
+                                    <th>Feature</th>
+                                    <th>ThemeSwitcher</th>
+                                    <th>ThemeCustomizer</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Light/Dark/System mode</td>
+                                    <td><i class="ph ph-check vd-text-success"></i></td>
+                                    <td><i class="ph ph-check vd-text-success"></i></td>
+                                </tr>
+                                <tr>
+                                    <td>Per-theme primary colors</td>
+                                    <td><i class="ph ph-x vd-text-muted"></i> (follows system)</td>
+                                    <td><i class="ph ph-check vd-text-success"></i></td>
+                                </tr>
+                                <tr>
+                                    <td>Color palette selection</td>
+                                    <td><i class="ph ph-x vd-text-muted"></i></td>
+                                    <td><i class="ph ph-check vd-text-success"></i> (18 colors)</td>
+                                </tr>
+                                <tr>
+                                    <td>Neutral scale</td>
+                                    <td><i class="ph ph-x vd-text-muted"></i></td>
+                                    <td><i class="ph ph-check vd-text-success"></i> (5 options)</td>
+                                </tr>
+                                <tr>
+                                    <td>Border radius</td>
+                                    <td><i class="ph ph-x vd-text-muted"></i></td>
+                                    <td><i class="ph ph-check vd-text-success"></i></td>
+                                </tr>
+                                <tr>
+                                    <td>Font family</td>
+                                    <td><i class="ph ph-x vd-text-muted"></i></td>
+                                    <td><i class="ph ph-check vd-text-success"></i></td>
+                                </tr>
+                                <tr>
+                                    <td>File size</td>
+                                    <td>~3KB</td>
+                                    <td>~15KB</td>
+                                </tr>
+                                <tr>
+                                    <td>Use case</td>
+                                    <td>Simple toggle</td>
+                                    <td>Full customization</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="vd-col-12 vd-col-md-6">
+            <div class="vd-card vd-card-glow demo-card">
+                <div class="vd-card-header">
+                    <h3>Per-Theme Primary Colors</h3>
+                </div>
+                <div class="vd-card-body">
+                    <p>When using ThemeCustomizer with ThemeSwitcher, you can define different primary colors for light
+                        and dark modes:</p>
+                    <div class="vd-code-snippet" data-collapsible>
+                        <button class="vd-code-snippet-toggle" aria-expanded="false">
+                            <span class="vd-code-snippet-toggle-icon"></span>
+                            <span>View Code</span>
+                        </button>
+                        <div class="vd-code-snippet-content">
+                            <div class="vd-code-snippet-header">
+                                <div class="vd-code-snippet-tabs" role="tablist">
+                                    <button class="vd-code-snippet-tab is-active" data-lang="js">JS</button>
+                                </div>
+                                <button class="vd-code-snippet-copy" aria-label="Copy code">
+                                    <span class="vd-code-snippet-copy-icon"></span>
+                                    <span class="vd-code-snippet-copy-text">Copy</span>
+                                </button>
+                            </div>
+                            <div class="vd-code-snippet-body">
+                                <pre class="vd-code-snippet-pane is-active"
+                                    data-lang="js"><code><span class="code-comment">// Override defaults before init</span>
+Object.<span class="code-function">assign</span>(window.ThemeCustomizer.DEFAULTS, {
+    <span class="code-comment">// Primary color in light mode</span>
+    PRIMARY_LIGHT: <span class="code-string">'black'</span>,
+    <span class="code-comment">// Primary color in dark mode</span>
+    PRIMARY_DARK: <span class="code-string">'amber'</span>
+});
+
+<span class="code-comment">// Initialize Vanduo</span>
+Vanduo.<span class="code-function">init</span>();</code></pre>
+                            </div>
+                        </div>
+                    </div>
+                    <p class="vd-mt-5 vd-text-sm vd-text-muted">When the user switches themes, the primary color
+                        automatically changes if they're using the default. If they've manually selected a color, it
+                        stays unchanged.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <h3 id="api" class="docs-heading">JavaScript API</h3>
+    <div class="vd-row">
+        <div class="vd-col-12 vd-col-md-6">
+            <div class="vd-card vd-card-glow demo-card">
+                <div class="vd-card-header">
+                    <h3>Programmatic Control</h3>
+                </div>
+                <div class="vd-card-body">
+                    <div class="vd-code-snippet" data-collapsible>
+                        <button class="vd-code-snippet-toggle" aria-expanded="false">
+                            <span class="vd-code-snippet-toggle-icon"></span>
+                            <span>View Code</span>
+                        </button>
+                        <div class="vd-code-snippet-content">
+                            <div class="vd-code-snippet-header">
+                                <div class="vd-code-snippet-tabs" role="tablist">
+                                    <button class="vd-code-snippet-tab is-active" data-lang="js">JS</button>
+                                </div>
+                                <button class="vd-code-snippet-copy" aria-label="Copy code">
+                                    <span class="vd-code-snippet-copy-icon"></span>
+                                    <span class="vd-code-snippet-copy-text">Copy</span>
+                                </button>
+                            </div>
+                            <div class="vd-code-snippet-body">
+                                <pre class="vd-code-snippet-pane is-active"
+                                    data-lang="js"><code><span class="code-comment">// Access the component</span>
+<span class="code-keyword">const</span> switcher = Vanduo.components.themeSwitcher;
+
+<span class="code-comment">// Get current preference</span>
+<span class="code-keyword">const</span> pref = switcher.<span class="code-function">getPreference</span>();
+<span class="code-comment">// Returns: 'system', 'light', or 'dark'</span>
+
+<span class="code-comment">// Set preference programmatically</span>
+switcher.<span class="code-function">setPreference</span>(<span class="code-string">'dark'</span>);
+
+<span class="code-comment">// Apply without changing preference</span>
+switcher.<span class="code-function">applyTheme</span>();</code></pre>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="vd-col-12 vd-col-md-6">
+            <div class="vd-card vd-card-glow demo-card">
+                <div class="vd-card-header">
+                    <h3>localStorage Key</h3>
+                </div>
+                <div class="vd-card-body">
+                    <div class="vd-table-responsive">
+                        <table class="vd-table vd-table-striped">
+                            <thead>
+                                <tr>
+                                    <th>Key</th>
+                                    <th>Default</th>
+                                    <th>Values</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>vanduo-theme-preference</code></td>
+                                    <td><code>system</code></td>
+                                    <td>system, light, dark</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <p class="vd-mt-5 vd-text-sm vd-text-muted">The preference is automatically saved and restored on
+                        page load.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <h3 class="docs-heading">CSS API</h3>
+    <div class="vd-table-responsive" style="margin-bottom: 3rem;">
+        <table class="vd-table vd-table-hover">
+            <thead>
+                <tr>
+                    <th style="width: 25%;">Attribute</th>
+                    <th style="width: 55%;">Description</th>
+                    <th style="width: 20%;">Type</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><code>data-toggle="theme"</code></td>
+                    <td>Required attribute on button or select element to bind theme switching behavior.</td>
+                    <td>Attribute</td>
+                </tr>
+                <tr>
+                    <td><code>data-theme="light|dark"</code></td>
+                    <td>Applied to <code><html></code> element. Controls CSS variable overrides for dark/light
+                        mode. Removed when using system preference.</td>
+                    <td>State Attribute</td>
+                </tr>
+                <tr>
+                    <td><code>.theme-current-label</code></td>
+                    <td>Class for span inside button to auto-update with current theme label (System, Light, Dark).
+                    </td>
+                    <td>Utility Class</td>
+                </tr>
+                <tr>
+                    <td><code>data-theme-initialized</code></td>
+                    <td>Added to elements after ThemeSwitcher binds events. Used for testing and debugging.</td>
+                    <td>State Attribute</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <h3 class="docs-heading">Best Practices</h3>
+    <div class="vd-row">
+        <div class="vd-col-12 vd-col-md-4">
+            <div class="vd-card demo-card">
+                <div class="vd-card-body">
+                    <h4><i class="ph ph-check-circle vd-text-success"></i> Use ThemeSwitcher when...</h4>
+                    <ul class="vd-mt-4">
+                        <li>You only need light/dark toggle</li>
+                        <li>File size is critical</li>
+                        <li>Quick integration needed</li>
+                        <li>Navbar space is limited</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="vd-col-12 vd-col-md-4">
+            <div class="vd-card demo-card">
+                <div class="vd-card-body">
+                    <h4><i class="ph ph-check-circle vd-text-success"></i> Use ThemeCustomizer when...</h4>
+                    <ul class="vd-mt-4">
+                        <li>Users need color customization</li>
+                        <li>You want per-theme primary colors</li>
+                        <li>Font/radius customization needed</li>
+                        <li>Building a theme-aware app</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="vd-col-12 vd-col-md-4">
+            <div class="vd-card demo-card">
+                <div class="vd-card-body">
+                    <h4><i class="ph ph-check-circle vd-text-success"></i> Use Both when...</h4>
+                    <ul class="vd-mt-4">
+                        <li>Quick toggle in navbar</li>
+                        <li>Full panel in settings</li>
+                        <li>Auto-coordination provided</li>
+                        <li>Best of both worlds</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/sections/docs-landing.html
+++ b/sections/docs-landing.html
@@ -107,7 +107,7 @@
                                 style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-primary);">Framework</span>
                             <code
                                 style="display: inline-flex; align-items: center; gap: 0.45rem; margin: 0; padding: 0.45rem 0.8rem; border-radius: var(--radius-sm); background: rgba(var(--primary-rgb), 0.1); color: var(--color-primary); font-size: 1.05rem; font-weight: 600;">
-                                <i class="ph ph-cube"></i> v1.2.7
+                                <i class="ph ph-cube"></i> v1.2.8
                             </code>
                         </div>
                         <div style="display: flex; align-items: center; justify-content: space-between; gap: 1rem;">
@@ -115,7 +115,7 @@
                                 style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-primary);">Docs</span>
                             <code
                                 style="display: inline-flex; align-items: center; gap: 0.45rem; margin: 0; padding: 0.45rem 0.8rem; border-radius: var(--radius-sm); background: rgba(var(--primary-rgb), 0.1); color: var(--color-primary); font-size: 1.05rem; font-weight: 600;">
-                                <i class="ph ph-book-open-text"></i> v1.2.7
+                                <i class="ph ph-book-open-text"></i> v1.2.8
                             </code>
                         </div>
                     </div>

--- a/sections/quick-start.html
+++ b/sections/quick-start.html
@@ -40,7 +40,7 @@
                         </div>
                     </div>
                     <p class="vd-text-sm vd-text-muted vd-mt-3"><strong>Tip:</strong> Pin to a specific version for
-                        production: <code>@v1.2.7</code> instead of <code>@main</code></p>
+                        production: <code>@v1.2.8</code> instead of <code>@main</code></p>
                 </div>
             </div>
         </div>

--- a/sections/sections.json
+++ b/sections/sections.json
@@ -121,6 +121,19 @@
               ]
             },
             {
+              "id": "theme-switcher",
+              "title": "Theme Switcher",
+              "file": "components/theme-switcher.html",
+              "icon": "ph-moon",
+              "keywords": [
+                "theme",
+                "switcher",
+                "dark mode",
+                "light mode",
+                "toggle"
+              ]
+            },
+            {
               "id": "buttons",
               "title": "Buttons",
               "file": "components/buttons.html",

--- a/tests/e2e/docs-view.spec.ts
+++ b/tests/e2e/docs-view.spec.ts
@@ -142,4 +142,110 @@ test.describe('4. Documentation View', () => {
     test.describe('Concepts Tab (#docs/concepts)', () => {
     });
 
+    test.describe('Theme Switching', () => {
+        test('Dark mode toggle changes primary color from black to amber', async ({ page }) => {
+            await page.goto('/#home');
+            await waitForSPA(page);
+
+            // Wait for Vanduo to initialize and apply preferences
+            await page.waitForFunction(() => {
+                return document.documentElement.hasAttribute('data-primary');
+            }, { timeout: 5000 });
+
+            // Get initial primary color (should be black in light mode per docs defaults)
+            const initialPrimary = await page.evaluate(() => {
+                return document.documentElement.getAttribute('data-primary');
+            });
+            expect(initialPrimary).toBe('black');
+
+            // Click the dark mode toggle button
+            const darkModeToggle = page.locator('#dark-mode-toggle');
+            await expect(darkModeToggle).toBeVisible();
+            
+            // Cycle through until we get to dark mode
+            // Initial: system -> click -> light -> click -> dark
+            let attempts = 0;
+            let currentTheme = await page.evaluate(() => {
+                return document.documentElement.getAttribute('data-theme');
+            });
+            
+            while (currentTheme !== 'dark' && attempts < 3) {
+                await darkModeToggle.click();
+                await page.waitForTimeout(400);
+                currentTheme = await page.evaluate(() => {
+                    return document.documentElement.getAttribute('data-theme');
+                });
+                attempts++;
+            }
+            
+            expect(currentTheme).toBe('dark');
+
+            // Wait for primary color to update ( coordination happens async )
+            await page.waitForTimeout(200);
+
+            // Verify primary color changed to amber (dark mode default per docs)
+            const darkPrimary = await page.evaluate(() => {
+                return document.documentElement.getAttribute('data-primary');
+            });
+            expect(darkPrimary).toBe('amber');
+
+            // Toggle back to light mode
+            attempts = 0;
+            while (currentTheme !== 'light' && attempts < 3) {
+                await darkModeToggle.click();
+                await page.waitForTimeout(400);
+                currentTheme = await page.evaluate(() => {
+                    return document.documentElement.getAttribute('data-theme');
+                });
+                attempts++;
+            }
+            
+            expect(currentTheme).toBe('light');
+
+            // Wait for primary color to update
+            await page.waitForTimeout(200);
+
+            // Verify back to black primary
+            const lightPrimary = await page.evaluate(() => {
+                return document.documentElement.getAttribute('data-primary');
+            });
+            expect(lightPrimary).toBe('black');
+        });
+
+        test('ThemeSwitcher and ThemeCustomizer stay in sync', async ({ page }) => {
+            await page.goto('/#home');
+            await waitForSPA(page);
+            await page.waitForTimeout(500);
+
+            // Open theme customizer panel
+            const customizerTrigger = page.locator('.vd-theme-customizer-trigger');
+            if (await customizerTrigger.count() > 0) {
+                await customizerTrigger.click();
+                await page.waitForTimeout(300);
+
+                // Click dark mode in customizer
+                const darkModeBtn = page.locator('.tc-mode-btn[data-mode="dark"]');
+                if (await darkModeBtn.count() > 0) {
+                    await darkModeBtn.click();
+                    await page.waitForTimeout(300);
+
+                    // Verify dark mode is active
+                    const theme = await page.evaluate(() => {
+                        return document.documentElement.getAttribute('data-theme');
+                    });
+                    expect(theme).toBe('dark');
+
+                    // Verify primary color swapped
+                    const primary = await page.evaluate(() => {
+                        return document.documentElement.getAttribute('data-primary');
+                    });
+                    expect(primary).toBe('amber');
+                }
+
+                // Close panel
+                await page.keyboard.press('Escape');
+            }
+        });
+    });
+
 });


### PR DESCRIPTION
## Summary
- align docs copy and metadata with the framework v1.2.8 release surface
- add the dedicated Theme Switcher documentation page and update Theme Customizer guidance
- refresh the docs landing experience and related content coverage already present on this branch
- switch the live docs shell from the locally vendored framework dist files to the pinned CDN release at `@v1.2.8`
- correct the site structured-data version in `index.html`

## Validation
- `pnpm test` (`88 passed`, `4 skipped`)