### PR TITLE
fix: add missing sections/kilo-oss.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
-        content="Vanduo Framework v1.3.3. Pure HTML, CSS, JS framework for beautiful websites. Zero runtime dependencies, no mandatory build tools, just clean code.">
+        content="Vanduo Framework v1.3.5. Pure HTML, CSS, JS framework for beautiful websites. Zero runtime dependencies, no mandatory build tools, just clean code.">
     <meta name="author" content="Vanduo Framework">
     <meta name="keywords"
         content="CSS framework, HTML framework, JavaScript framework, static website, no dependencies, pure CSS, pure JavaScript, responsive design, UI components, Lithuania">
@@ -18,7 +18,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://vanduo.dev/">
-    <meta property="og:title" content="Vanduo Framework v1.3.3 - Pure HTML, CSS, JS Framework">
+    <meta property="og:title" content="Vanduo Framework v1.3.5 - Pure HTML, CSS, JS Framework">
     <meta property="og:description"
         content="Essential just like water is. Zero-dependency framework for beautiful static websites.">
     <meta property="og:image" content="https://vanduo.dev/images/og-image.png">
@@ -28,7 +28,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://vanduo.dev/">
-    <meta name="twitter:title" content="Vanduo Framework v1.3.3 - Pure HTML, CSS, JS Framework">
+    <meta name="twitter:title" content="Vanduo Framework v1.3.5 - Pure HTML, CSS, JS Framework">
     <meta name="twitter:description"
         content="Essential just like water is. Zero-dependency framework for beautiful static websites.">
     <meta name="twitter:image" content="https://vanduo.dev/images/twitter-card.png">
@@ -49,7 +49,7 @@
                 : (isLocalPreview ? 'local' : 'cdn');
             var basePath = mode === 'local'
                 ? './dist'
-                : 'https://cdn.jsdelivr.net/gh/vanduo-oss/framework@v1.3.4/dist';
+                : 'https://cdn.jsdelivr.net/gh/vanduo-oss/framework@v1.3.5/dist';
 
             window.__VANDUO_FRAMEWORK_ASSET_MODE = mode;
             window.__VANDUO_FRAMEWORK_ASSETS = {
@@ -93,7 +93,7 @@
         "price": "0",
         "priceCurrency": "USD"
       },
-    "softwareVersion": "1.3.3",
+    "softwareVersion": "1.3.5",
       "license": "https://opensource.org/licenses/MIT",
       "programmingLanguage": ["HTML", "CSS", "JavaScript"]
     }

--- a/sections/kilo-oss.html
+++ b/sections/kilo-oss.html
@@ -1,0 +1,53 @@
+<section id="kilo-oss-page" class="about-section" style="padding-bottom: 6rem;">
+    <div class="about-header">
+        <div class="vd-container-responsive">
+            <h2 style="color: var(--color-primary);"><i class="ph ph-heart"></i> Kilo Loves Open Source</h2>
+            <p class="vd-text-lg vd-text-muted">
+                Our open-source journey and Kilo OSS sponsorship.
+            </p>
+        </div>
+    </div>
+
+    <div class="vd-container-responsive" style="padding-top: 3rem;">
+        <div class="vd-row">
+            <div class="vd-col-12">
+                <div class="vd-card vd-glass about-card">
+                    <div class="vd-card-body">
+                        <h3><i class="ph ph-seal-check"></i> Sponsorship</h3>
+                        <p>
+                            Vanduo Framework was selected for the <strong>Kilo Open Source Sponsorship Program</strong>
+                            at the <strong>Seed tier</strong>.
+                        </p>
+                        <p>
+                            The sponsorship includes five enterprise seats for AI-assisted code review, helping us keep
+                            pull requests consistent and maintain a fast feedback loop.
+                        </p>
+                        <a href="https://kilo.ai/oss" target="_blank" rel="noopener noreferrer"
+                            class="vd-btn vd-btn-primary">
+                            <i class="ph ph-arrow-square-out"></i> Explore Kilo OSS
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="vd-row vd-mt-6">
+            <div class="vd-col-12">
+                <div class="vd-card vd-glass about-card">
+                    <div class="vd-card-body">
+                        <h3><i class="ph ph-git-branch"></i> Why this matters</h3>
+                        <p>
+                            Open-source projects thrive when maintainers can spend more time shipping, less time stuck
+                            in maintenance overhead. Sponsorship support allows us to keep improving docs, harden core
+                            components, and respond to community feedback faster.
+                        </p>
+                        <p>
+                            Vanduo remains fully open source, MIT licensed, and community-driven. If you are building
+                            with Vanduo, contributing examples, or reporting issues, you are part of this story too.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
## Summary
- Adds the missing `sections/kilo-oss.html` page that was referenced in `sections.json` but never committed, causing `#kilo-oss` to 404.
- Bumps meta tag version strings in `index.html` from v1.3.3 to v1.3.5.

## Root cause
`kilo-oss.html` was created locally but never staged/committed before the v1.3.5 PR was raised.

## Test plan
- [ ] Navigate to `#kilo-oss` — page loads with "Kilo Loves Open Source" content
- [ ] No 404 in network tab

Made with [Cursor](https://cursor.com)