### PR TITLE
docs: prepare v1.3.6 release — faster deep-link nav, mobile TOC feedback

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -576,6 +576,12 @@
             font-weight: 500;
         }
 
+        .doc-nav-link.is-navigating {
+            color: var(--color-primary);
+            background-color: var(--bg-secondary);
+            opacity: 0.9;
+        }
+
         .doc-nav-link i {
             font-size: 1.1em;
             margin-right: 0.375rem;
@@ -1368,6 +1374,15 @@
         /* Full-width docs container — remove max-width constraint */
         #docs-view .vd-container-responsive {
             max-width: none;
+        }
+
+        #dynamic-content {
+            overflow-anchor: auto;
+        }
+
+        #dynamic-content > section {
+            content-visibility: auto;
+            contain-intrinsic-size: 1px 600px;
         }
 
         @media (max-width: 767.98px) {

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
-        content="Vanduo Framework v1.3.5. Pure HTML, CSS, JS framework for beautiful websites. Zero runtime dependencies, no mandatory build tools, just clean code.">
+        content="Vanduo Framework v1.3.6. Pure HTML, CSS, JS framework for beautiful websites. Zero runtime dependencies, no mandatory build tools, just clean code.">
     <meta name="author" content="Vanduo Framework">
     <meta name="keywords"
         content="CSS framework, HTML framework, JavaScript framework, static website, no dependencies, pure CSS, pure JavaScript, responsive design, UI components, Lithuania">
@@ -18,7 +18,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://vanduo.dev/">
-    <meta property="og:title" content="Vanduo Framework v1.3.5 - Pure HTML, CSS, JS Framework">
+    <meta property="og:title" content="Vanduo Framework v1.3.6 - Pure HTML, CSS, JS Framework">
     <meta property="og:description"
         content="Essential just like water is. Zero-dependency framework for beautiful static websites.">
     <meta property="og:image" content="https://vanduo.dev/images/og-image.png">
@@ -28,7 +28,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://vanduo.dev/">
-    <meta name="twitter:title" content="Vanduo Framework v1.3.5 - Pure HTML, CSS, JS Framework">
+    <meta name="twitter:title" content="Vanduo Framework v1.3.6 - Pure HTML, CSS, JS Framework">
     <meta name="twitter:description"
         content="Essential just like water is. Zero-dependency framework for beautiful static websites.">
     <meta name="twitter:image" content="https://vanduo.dev/images/twitter-card.png">
@@ -61,6 +61,7 @@
         })();
     </script>
     <link id="vanduo-framework-css" rel="stylesheet">
+    <link rel="prefetch" href="./sections/sections.json" as="fetch">
     <script>
         (function () {
             var frameworkCss = document.getElementById('vanduo-framework-css');
@@ -93,7 +94,7 @@
         "price": "0",
         "priceCurrency": "USD"
       },
-    "softwareVersion": "1.3.5",
+    "softwareVersion": "1.3.6",
       "license": "https://opensource.org/licenses/MIT",
       "programmingLanguage": ["HTML", "CSS", "JavaScript"]
     }
@@ -282,6 +283,9 @@
             loadScript(assetState.jsSrc, 'data-framework-js', assetState.mode)
                 .then(function () {
                     return loadScript('js/lazy-loader.js');
+                })
+                .then(function () {
+                    return loadScript('js/section-cache.js');
                 })
                 .then(function () {
                     return loadScript('js/app.js');

--- a/js/app.js
+++ b/js/app.js
@@ -45,6 +45,10 @@ let docScrollLoaderEl = null;
 let docScrollLoaderTargetId = null;
 let docScrollLoaderFallbackTimer = null;
 let requestedDocScrollLoaderSectionId = null;
+let currentNavigationController = null;
+const SECTION_PRELOAD_CONCURRENCY = 6;
+const sectionPrefetching = new Set();
+let docsWarmupTimer = null;
 
 function releasePendingDocNavigation(delayMs = 0) {
     if (pendingDocNavigationReleaseTimer) {
@@ -66,6 +70,12 @@ function clearDocScrollLoaderFallbackTimer() {
         clearTimeout(docScrollLoaderFallbackTimer);
         docScrollLoaderFallbackTimer = null;
     }
+}
+
+function clearNavigatingNavLinks() {
+    document.querySelectorAll('.doc-nav-link.is-navigating').forEach(function (link) {
+        link.classList.remove('is-navigating');
+    });
 }
 
 function requestDocScrollLoaderForRoute(route) {
@@ -150,6 +160,7 @@ function getDocScrollLoaderHtml() {
 
 function hideDocScrollLoader() {
     clearDocScrollLoaderFallbackTimer();
+    clearNavigatingNavLinks();
     if (docScrollLoaderEl) {
         docScrollLoaderEl.remove();
         docScrollLoaderEl = null;
@@ -195,7 +206,13 @@ function settleDocScrollLoader(sectionId) {
             return;
         }
 
-        var reachedTarget = target.getBoundingClientRect().top <= (SCROLL_SPY_OFFSET + 10);
+        var targetTop = target.getBoundingClientRect().top;
+        var driftedDown = targetTop > (SCROLL_SPY_OFFSET + 32);
+        if (driftedDown) {
+            target.scrollIntoView({ behavior: 'auto', block: 'start' });
+            targetTop = target.getBoundingClientRect().top;
+        }
+        var reachedTarget = targetTop <= (SCROLL_SPY_OFFSET + 10);
         if (reachedTarget || Date.now() >= deadline) {
             hideDocScrollLoader();
             return;
@@ -243,6 +260,45 @@ function getOrderedIds(tabKey) {
     var tab = registry.tabs[tabKey];
     if (!tab) return [];
     return tab.categories.flatMap(function (c) { return c.sections.map(function (s) { return s.id; }); });
+}
+
+function parseSectionIdFromRoute(route) {
+    if (typeof route !== 'string' || !route.startsWith('docs/')) return null;
+    var parsed = parseHash('#' + route);
+    return parsed && parsed.section ? parsed.section : null;
+}
+
+function getCachedSectionHtml(sectionId) {
+    if (!window.VanduoSectionCache || !sectionId) return null;
+    return window.VanduoSectionCache.get(sectionId);
+}
+
+function setCachedSectionHtml(sectionId, html) {
+    if (!window.VanduoSectionCache || !sectionId || typeof html !== 'string') return;
+    window.VanduoSectionCache.set(sectionId, html);
+}
+
+async function prefetchSection(sectionId, options = {}) {
+    if (!sectionId || loadedSections.has(sectionId) || loadingSections.has(sectionId)) return;
+    if (getCachedSectionHtml(sectionId)) return;
+    if (sectionPrefetching.has(sectionId)) return;
+
+    var meta = findSectionMeta(sectionId);
+    if (!meta || !meta.section || !meta.section.file) return;
+
+    sectionPrefetching.add(sectionId);
+    try {
+        var res = await fetch(SECTIONS_BASE + meta.section.file, { signal: options.signal });
+        if (!res.ok) return;
+        var html = await res.text();
+        if (html) setCachedSectionHtml(sectionId, html);
+    } catch (err) {
+        if (!err || err.name !== 'AbortError') {
+            console.warn('Section prefetch failed for', sectionId, err);
+        }
+    } finally {
+        sectionPrefetching.delete(sectionId);
+    }
 }
 
 /* ── Registry loading ─────────────────────────── */
@@ -448,20 +504,45 @@ async function loadPage(pageId) {
 }
 
 /* ── Section loading (docs) ───────────────────── */
-async function preloadSectionsBefore(tabKey, targetSectionId) {
+async function preloadSectionsBefore(tabKey, targetSectionId, options = {}) {
+    var signal = options.signal;
     var orderedIds = getOrderedIds(tabKey);
     var targetIndex = orderedIds.indexOf(targetSectionId);
     if (targetIndex <= 0) return;
 
+    var pendingIds = [];
     for (var i = 0; i < targetIndex; i++) {
         var id = orderedIds[i];
         if (!loadedSections.has(id) && !loadingSections.has(id)) {
-            await loadSection(id, false);
+            pendingIds.push(id);
         }
     }
+
+    if (!pendingIds.length) {
+        setupInfiniteScroll();
+        return;
+    }
+
+    var cursor = 0;
+    var workerCount = Math.min(SECTION_PRELOAD_CONCURRENCY, pendingIds.length);
+    async function worker() {
+        while (cursor < pendingIds.length) {
+            if (signal && signal.aborted) return;
+            var id = pendingIds[cursor];
+            cursor += 1;
+            await loadSection(id, false, { signal: signal, skipInfiniteRefresh: true });
+        }
+    }
+
+    await Promise.all(Array.from({ length: workerCount }, worker));
+    setupInfiniteScroll();
 }
 
-async function loadSection(sectionId, autoScroll = true) {
+async function loadSection(sectionId, autoScroll = true, options = {}) {
+    var signal = options.signal;
+    var skipInfiniteRefresh = options.skipInfiniteRefresh === true;
+    if (signal && signal.aborted) return;
+
     if (autoScroll && requestedDocScrollLoaderSectionId === sectionId) {
         showDocScrollLoader(sectionId);
         requestedDocScrollLoaderSectionId = null;
@@ -486,7 +567,8 @@ async function loadSection(sectionId, autoScroll = true) {
     }
 
     if (autoScroll) {
-        await preloadSectionsBefore(meta.tab, sectionId);
+        await preloadSectionsBefore(meta.tab, sectionId, { signal: signal });
+        if (signal && signal.aborted) return;
         if (loadedSections.has(sectionId)) {
             var existingSection = document.getElementById(sectionId);
             if (existingSection) existingSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -531,15 +613,25 @@ async function loadSection(sectionId, autoScroll = true) {
     setActiveNavLink(sectionId);
 
     try {
-        var url = SECTIONS_BASE + meta.section.file;
-        var res = await fetch(url);
-        if (!res.ok) throw new Error('Failed to load ' + url);
-        var html = await res.text();
+        var html = getCachedSectionHtml(sectionId);
+        if (!html) {
+            var url = SECTIONS_BASE + meta.section.file;
+            var res = await fetch(url, { signal: signal });
+            if (!res.ok) throw new Error('Failed to load ' + url);
+            html = await res.text();
+            setCachedSectionHtml(sectionId, html);
+        }
         var wrap = document.createElement('div');
         wrap.innerHTML = html.trim();
         var sectionEl = wrap.firstElementChild;
         if (sectionEl) {
-            container.replaceChild(sectionEl, placeholder);
+            if (document.startViewTransition && autoScroll) {
+                await document.startViewTransition(function () {
+                    container.replaceChild(sectionEl, placeholder);
+                }).finished;
+            } else {
+                container.replaceChild(sectionEl, placeholder);
+            }
             loadedSections.add(sectionId);
             if (typeof Vanduo !== 'undefined') Vanduo.init();
             hideDisabledCodeTabs(sectionEl);
@@ -551,7 +643,9 @@ async function loadSection(sectionId, autoScroll = true) {
         } else {
             placeholder.remove();
         }
-        setupInfiniteScroll();
+        if (!skipInfiniteRefresh) {
+            setupInfiniteScroll();
+        }
 
         var target = document.getElementById(sectionId);
         if (target && autoScroll) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -567,6 +661,10 @@ async function loadSection(sectionId, autoScroll = true) {
             releasePendingDocNavigation(450);
         }
     } catch (err) {
+        if (err && err.name === 'AbortError') {
+            placeholder.remove();
+            return;
+        }
         hideDocScrollLoader();
         placeholder.remove();
         console.error(err);
@@ -578,7 +676,9 @@ async function loadSection(sectionId, autoScroll = true) {
 }
 
 /* ── Switch docs tab ──────────────────────────── */
-async function switchTab(tabKey) {
+async function switchTab(tabKey, options = {}) {
+    var signal = options.signal;
+    if (signal && signal.aborted) return;
     hideDocScrollLoader();
     if (currentTab === tabKey) return;
     currentTab = tabKey;
@@ -603,8 +703,10 @@ async function switchTab(tabKey) {
 
     var orderedIds = getOrderedIds(tabKey);
     if (orderedIds.length > 0) {
-        await loadSection(orderedIds[0]);
+        await loadSection(orderedIds[0], true, { signal: signal });
     }
+    if (signal && signal.aborted) return;
+    scheduleDocsWarmup(tabKey);
 }
 
 /* ── Scroll-spy ───────────────────────────────── */
@@ -733,7 +835,30 @@ function loadNextSection() {
 
     var nextIndex = maxIndex + 1;
     if (nextIndex < orderedIds.length) {
-        loadSection(orderedIds[nextIndex], false); // autoScroll = false
+        loadSection(orderedIds[nextIndex], false, { skipInfiniteRefresh: true }) // autoScroll = false
+            .finally(function () {
+                setupInfiniteScroll();
+            });
+    }
+}
+
+function scheduleDocsWarmup(tabKey) {
+    if (!tabKey) return;
+    if (docsWarmupTimer) {
+        clearTimeout(docsWarmupTimer);
+        docsWarmupTimer = null;
+    }
+
+    var runWarmup = function () {
+        getOrderedIds(tabKey).forEach(function (id) {
+            prefetchSection(id);
+        });
+    };
+
+    if (typeof window.requestIdleCallback === 'function') {
+        window.requestIdleCallback(runWarmup, { timeout: 1500 });
+    } else {
+        docsWarmupTimer = setTimeout(runWarmup, 500);
     }
 }
 
@@ -981,6 +1106,12 @@ async function navigate(route) {
 }
 
 async function handleRoute() {
+    if (currentNavigationController) {
+        currentNavigationController.abort();
+    }
+    currentNavigationController = new AbortController();
+    var signal = currentNavigationController.signal;
+
     var parsed = parseHash(location.hash);
 
     if (parsed.view === 'home' || parsed.view === 'about' || parsed.view === 'changelog' || parsed.view === 'kilo-oss' || parsed.view === 'docs-landing' || parsed.view === 'labs') {
@@ -998,11 +1129,15 @@ async function handleRoute() {
     setActiveNavbarLink('docs');
 
     if (currentTab !== parsed.tab) {
-        await switchTab(parsed.tab);
+        await switchTab(parsed.tab, { signal: signal });
+        if (signal.aborted) return;
     }
 
     if (parsed.section) {
-        await loadSection(parsed.section);
+        await loadSection(parsed.section, true, { signal: signal });
+        if (!signal.aborted) {
+            scheduleDocsWarmup(parsed.tab);
+        }
     }
 }
 
@@ -1174,11 +1309,24 @@ if (dynamicNavList) {
         if (!link) return;
         e.preventDefault();
         var id = link.getAttribute('data-section');
+        clearNavigatingNavLinks();
+        link.classList.add('is-navigating');
+        requestDocScrollLoaderForRoute('docs/' + id);
         closeMobileToc();
         var sidebarFilterInput = document.getElementById('doc-sidebar-filter-input');
         if (sidebarFilterInput) { sidebarFilterInput.value = ''; filterSidebarNav(''); }
         navigate('docs/' + id);
     });
+    dynamicNavList.addEventListener('pointerenter', function (e) {
+        var link = e.target.closest('.doc-nav-link[data-section]');
+        if (!link) return;
+        prefetchSection(link.getAttribute('data-section'));
+    }, true);
+    dynamicNavList.addEventListener('touchstart', function (e) {
+        var link = e.target.closest('.doc-nav-link[data-section]');
+        if (!link) return;
+        prefetchSection(link.getAttribute('data-section'));
+    }, { passive: true });
 }
 
 /* ── Sidebar filter events ────────────────────── */
@@ -1713,6 +1861,18 @@ function initGlobalSearch() {
             selectGlobalSearchResult(idx);
         }
     });
+    document.getElementById('global-search-results').addEventListener('pointerover', function (e) {
+        var item = e.target.closest('.global-search-result[data-route]');
+        if (!item) return;
+        var sectionId = parseSectionIdFromRoute(item.dataset.route);
+        if (sectionId) prefetchSection(sectionId);
+    });
+    document.getElementById('global-search-results').addEventListener('touchstart', function (e) {
+        var item = e.target.closest('.global-search-result[data-route]');
+        if (!item) return;
+        var sectionId = parseSectionIdFromRoute(item.dataset.route);
+        if (sectionId) prefetchSection(sectionId);
+    }, { passive: true });
 
     // Cmd/Ctrl+K global shortcut
     document.addEventListener('keydown', function (e) {
@@ -1911,6 +2071,18 @@ function initGlobalSearch() {
             closeHeroDropdown();
         }
     });
+    document.addEventListener('pointerover', function (e) {
+        var item = e.target.closest('.hero-search-dropdown .global-search-result[data-route]');
+        if (!item) return;
+        var sectionId = parseSectionIdFromRoute(item.getAttribute('data-route'));
+        if (sectionId) prefetchSection(sectionId);
+    });
+    document.addEventListener('touchstart', function (e) {
+        var item = e.target.closest('.hero-search-dropdown .global-search-result[data-route]');
+        if (!item) return;
+        var sectionId = parseSectionIdFromRoute(item.getAttribute('data-route'));
+        if (sectionId) prefetchSection(sectionId);
+    }, { passive: true });
 }
 
 /* ── Dark Mode Toggle Icon Sync ───────────────── */
@@ -1984,4 +2156,15 @@ function initGlobalSearch() {
     });
 
     await handleRoute();
+
+    if ('serviceWorker' in navigator) {
+        var isLocalPreview = window.location.protocol === 'file:'
+            || window.location.hostname === 'localhost'
+            || window.location.hostname === '127.0.0.1';
+        if (!isLocalPreview) {
+            navigator.serviceWorker.register('./sw.js').catch(function (err) {
+                console.warn('Service worker registration failed', err);
+            });
+        }
+    }
 })();

--- a/js/app.js
+++ b/js/app.js
@@ -13,8 +13,8 @@ if (typeof window.Vanduo === 'undefined') {
             FONT: 'lato',
             PRIMARY_LIGHT: 'black',
             PRIMARY_DARK: 'amber',
-            NEUTRAL: 'neutral',
-            RADIUS: '0.375'
+            NEUTRAL: 'slate',
+            RADIUS: '0.5'
         });
     }
     window.Vanduo.init();

--- a/js/section-cache.js
+++ b/js/section-cache.js
@@ -1,0 +1,77 @@
+'use strict';
+
+(function () {
+    var CACHE_KEY = 'vd:sectionCache:v1';
+    var MAX_ENTRIES = 20;
+    var entries = new Map();
+
+    function trimToLimit() {
+        while (entries.size > MAX_ENTRIES) {
+            var firstKey = entries.keys().next().value;
+            if (!firstKey) break;
+            entries.delete(firstKey);
+        }
+    }
+
+    function flush() {
+        try {
+            var payload = {};
+            entries.forEach(function (value, key) {
+                payload[key] = value;
+            });
+            window.sessionStorage.setItem(CACHE_KEY, JSON.stringify(payload));
+        } catch (err) {
+            // Ignore storage quota or serialization failures.
+        }
+    }
+
+    function touch(key) {
+        if (!entries.has(key)) return;
+        var value = entries.get(key);
+        entries.delete(key);
+        entries.set(key, value);
+    }
+
+    function loadFromStorage() {
+        try {
+            var raw = window.sessionStorage.getItem(CACHE_KEY);
+            if (!raw) return;
+            var parsed = JSON.parse(raw);
+            Object.keys(parsed).forEach(function (key) {
+                if (typeof parsed[key] === 'string') {
+                    entries.set(key, parsed[key]);
+                }
+            });
+            trimToLimit();
+        } catch (err) {
+            // Ignore malformed data and continue with memory-only cache.
+        }
+    }
+
+    loadFromStorage();
+
+    window.VanduoSectionCache = {
+        has: function (key) {
+            return entries.has(key);
+        },
+        get: function (key) {
+            if (!entries.has(key)) return null;
+            touch(key);
+            return entries.get(key) || null;
+        },
+        set: function (key, html) {
+            if (!key || typeof html !== 'string') return;
+            entries.set(key, html);
+            trimToLimit();
+            flush();
+        },
+        clear: function () {
+            entries.clear();
+            try {
+                window.sessionStorage.removeItem(CACHE_KEY);
+            } catch (err) {
+                // Ignore storage failures.
+            }
+        }
+    };
+})();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanduo-docs",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "description": "Vanduo documentation and website",
   "scripts": {

--- a/sections/changelog.html
+++ b/sections/changelog.html
@@ -15,6 +15,140 @@
         <div class="vd-container-responsive" style="max-width: 1200px;">
 
             <!-- ═══════════════════════════════════════════════ -->
+            <!-- Version 1.3.6                                   -->
+            <!-- ═══════════════════════════════════════════════ -->
+            <article class="version-card">
+                <header class="version-header">
+                    <span class="vd-badge vd-badge-primary" style="font-size: 1rem; padding: 0.5rem 1rem;">v1.3.6</span>
+                    <span style="color: var(--text-secondary); font-size: 0.95rem;">
+                        <i class="ph ph-calendar mr-1"></i>April 16, 2026
+                    </span>
+                    <span class="vd-badge vd-badge-info" style="font-size: 0.75rem;">Latest</span>
+                </header>
+                <div class="version-body">
+                    <div class="vd-row">
+                        <div class="vd-col-12 vd-col-md-6">
+                            <h4><i class="ph ph-cube mr-2" style="color: var(--color-primary);"></i>Framework</h4>
+                            <div class="change-group">
+                                <h5>Notes</h5>
+                                <ul class="change-list">
+                                    <li class="change-item">
+                                        <i class="ph ph-info" style="color: var(--color-info);"></i>
+                                        <div>
+                                            <strong>No framework changes in this release</strong>
+                                            <p>Framework bundle remains pinned at <strong>v1.3.5</strong>. This is a docs-only release focused on mobile navigation UX, deep-link performance, and offline resilience.</p>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="vd-col-12 vd-col-md-6">
+                            <h4><i class="ph ph-book-open-text mr-2" style="color: var(--color-primary);"></i>Documentation</h4>
+                            <div class="change-group">
+                                <h5>New</h5>
+                                <ul class="change-list">
+                                    <li class="change-item">
+                                        <i class="ph ph-database" style="color: var(--color-success);"></i>
+                                        <div>
+                                            <strong>New: Section HTML cache with <code>VanduoSectionCache</code></strong>
+                                            <p>An in-memory LRU cache (backed by <code>sessionStorage</code>) now stores fetched section HTML so revisiting a page is effectively instant. Delivered as a standalone module at <code>js/section-cache.js</code>, consulted by <code>loadSection</code> and populated by both navigation and prefetching paths.</p>
+                                        </div>
+                                    </li>
+                                    <li class="change-item">
+                                        <i class="ph ph-cursor-click" style="color: var(--color-success);"></i>
+                                        <div>
+                                            <strong>New: Hover / touch prefetching</strong>
+                                            <p>Sidebar links and global search results now warm the section cache on <code>pointerenter</code> and <code>touchstart</code>, so the target section is typically ready before the click lands.</p>
+                                        </div>
+                                    </li>
+                                    <li class="change-item">
+                                        <i class="ph ph-hourglass-low" style="color: var(--color-success);"></i>
+                                        <div>
+                                            <strong>New: Idle warm-up of the current tab</strong>
+                                            <p>After the initial section loads, <code>requestIdleCallback</code> (with a <code>setTimeout</code> fallback) quietly prefetches the remaining sections of the active tab (Components or Guides), making in-tab navigation feel synchronous.</p>
+                                        </div>
+                                    </li>
+                                    <li class="change-item">
+                                        <i class="ph ph-cloud-check" style="color: var(--color-success);"></i>
+                                        <div>
+                                            <strong>New: Service worker for section HTML</strong>
+                                            <p>Added <code>docs/sw.js</code> — a minimal stale-while-revalidate service worker scoped to <code>/sections/**</code>. It serves cached HTML instantly while refreshing in the background, and is versioned so old caches are cleaned on activate. Registered only on non-local origins.</p>
+                                        </div>
+                                    </li>
+                                    <li class="change-item">
+                                        <i class="ph ph-arrows-clockwise" style="color: var(--color-success);"></i>
+                                        <div>
+                                            <strong>New: View Transitions during section swaps</strong>
+                                            <p>When the browser supports it, <code>document.startViewTransition</code> wraps section replacement so the old and new content cross-fade instead of flashing.</p>
+                                        </div>
+                                    </li>
+                                </ul>
+                                <h5>Updates</h5>
+                                <ul class="change-list">
+                                    <li class="change-item">
+                                        <i class="ph ph-spinner-gap" style="color: var(--color-info);"></i>
+                                        <div>
+                                            <strong>Update: Instant mobile TOC feedback</strong>
+                                            <p>Clicking a sidebar / mobile TOC link now immediately shows the skeleton scroll loader and adds an <code>.is-navigating</code> pressed state to the link, so users get visual confirmation before the section loads. Previously, mobile Chrome taps felt unresponsive during the fetch.</p>
+                                        </div>
+                                    </li>
+                                    <li class="change-item">
+                                        <i class="ph ph-lightning" style="color: var(--color-info);"></i>
+                                        <div>
+                                            <strong>Update: Parallel preload for deep-link navigation</strong>
+                                            <p><code>preloadSectionsBefore</code> now fetches preceding sections in parallel with a concurrency limit (<code>Promise.all</code>, max 6 in flight) instead of serially. Deep-linking into a section far down the list — especially via global search results — arrives dramatically faster on mobile networks.</p>
+                                        </div>
+                                    </li>
+                                    <li class="change-item">
+                                        <i class="ph ph-x-circle" style="color: var(--color-info);"></i>
+                                        <div>
+                                            <strong>Update: Abortable navigation</strong>
+                                            <p><code>handleRoute</code> threads an <code>AbortController</code> through <code>switchTab</code>, <code>loadSection</code>, and <code>preloadSectionsBefore</code>. Rapid successive clicks now cancel stale fetches instead of racing each other, preventing jumps to the previously-requested section.</p>
+                                        </div>
+                                    </li>
+                                    <li class="change-item">
+                                        <i class="ph ph-gauge" style="color: var(--color-info);"></i>
+                                        <div>
+                                            <strong>Update: Offscreen section rendering optimized</strong>
+                                            <p><code>#dynamic-content &gt; section</code> now uses <code>content-visibility: auto</code> with <code>contain-intrinsic-size</code>, letting the browser skip layout and paint of offscreen sections until they scroll near the viewport.</p>
+                                        </div>
+                                    </li>
+                                    <li class="change-item">
+                                        <i class="ph ph-anchor-simple" style="color: var(--color-info);"></i>
+                                        <div>
+                                            <strong>Update: Scroll anchoring during parallel inserts</strong>
+                                            <p>Added <code>overflow-anchor: auto</code> on <code>#dynamic-content</code> and a re-anchor pass in <code>settleDocScrollLoader</code> that calls <code>scrollIntoView</code> on the target section if preceding content inserted after scroll caused the anchor to drift.</p>
+                                        </div>
+                                    </li>
+                                    <li class="change-item">
+                                        <i class="ph ph-link" style="color: var(--color-info);"></i>
+                                        <div>
+                                            <strong>Update: <code>sections/sections.json</code> prefetched on load</strong>
+                                            <p>Added <code>&lt;link rel="prefetch"&gt;</code> for the sections metadata so the very first navigation doesn't wait on it.</p>
+                                        </div>
+                                    </li>
+                                    <li class="change-item">
+                                        <i class="ph ph-palette" style="color: var(--color-info);"></i>
+                                        <div>
+                                            <strong>Update: Theme customizer defaults for docs site</strong>
+                                            <p>Docs-site <code>ThemeCustomizer.DEFAULTS</code> override now uses <code>slate</code> for neutral and <code>0.5</code> for radius (previously <code>neutral</code> / <code>0.375</code>), giving a softer default look. The local storage defaults table on the Theme Customizer component page was updated to match.</p>
+                                        </div>
+                                    </li>
+                                    <li class="change-item">
+                                        <i class="ph ph-bookmark-simple" style="color: var(--color-info);"></i>
+                                        <div>
+                                            <strong>Update: Docs meta version bumped to v1.3.6</strong>
+                                            <p><code>package.json</code>, JSON-LD <code>softwareVersion</code>, and the <code>&lt;meta&gt;</code> / Open Graph / Twitter titles now reference <strong>v1.3.6</strong>. The framework CDN pin remains at <code>@v1.3.5</code>.</p>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </article>
+
+            <!-- ═══════════════════════════════════════════════ -->
             <!-- Version 1.3.5                                   -->
             <!-- ═══════════════════════════════════════════════ -->
             <article class="version-card">
@@ -23,7 +157,6 @@
                     <span style="color: var(--text-secondary); font-size: 0.95rem;">
                         <i class="ph ph-calendar mr-1"></i>April 15, 2026
                     </span>
-                    <span class="vd-badge vd-badge-info" style="font-size: 0.75rem;">Latest</span>
                 </header>
                 <div class="version-body">
                     <div class="vd-row">

--- a/sections/components/theme-customizer.html
+++ b/sections/components/theme-customizer.html
@@ -247,12 +247,12 @@
                                 </tr>
                                 <tr>
                                     <td><code>vanduo-neutral-color</code></td>
-                                    <td><code>gray</code></td>
+                                    <td><code>slate</code></td>
                                     <td>Neutral/gray scale</td>
                                 </tr>
                                 <tr>
                                     <td><code>vanduo-radius</code></td>
-                                    <td><code>0.25</code></td>
+                                    <td><code>0.5</code></td>
                                     <td>Border radius scale</td>
                                 </tr>
                                 <tr>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const SECTION_CACHE = 'vanduo-sections-v1';
+
+self.addEventListener('install', function () {
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', function (event) {
+    event.waitUntil((async function () {
+        const keys = await caches.keys();
+        await Promise.all(keys.map(function (key) {
+            if (key !== SECTION_CACHE && key.startsWith('vanduo-sections-')) {
+                return caches.delete(key);
+            }
+            return Promise.resolve();
+        }));
+        await self.clients.claim();
+    })());
+});
+
+self.addEventListener('fetch', function (event) {
+    const request = event.request;
+    if (request.method !== 'GET') return;
+
+    const url = new URL(request.url);
+    if (url.origin !== self.location.origin) return;
+    if (!url.pathname.includes('/sections/')) return;
+
+    event.respondWith((async function () {
+        const cache = await caches.open(SECTION_CACHE);
+        const cached = await cache.match(request);
+        const networkPromise = fetch(request).then(function (response) {
+            if (response && response.ok) {
+                cache.put(request, response.clone());
+            }
+            return response;
+        }).catch(function () {
+            return null;
+        });
+
+        if (cached) {
+            networkPromise;
+            return cached;
+        }
+
+        const networkResponse = await networkPromise;
+        if (networkResponse) return networkResponse;
+        return new Response('Offline', { status: 503, statusText: 'Offline' });
+    })());
+});


### PR DESCRIPTION
## Summary

Docs-only release (framework stays pinned at **v1.3.5**) focused on lazy-loading UX, deep-link performance, and mobile Chrome responsiveness.

### Root-cause fixes
- **Mobile TOC taps felt dead.** Clicks on sidebar / mobile TOC links now immediately paint the skeleton scroll loader and toggle an `.is-navigating` pressed state, so users get feedback before the section loads.
- **Global-search deep links took too long.** `preloadSectionsBefore` was fetching preceding sections serially. It now runs a concurrency-limited `Promise.all` (max 6 in flight), so deep links arrive much faster — especially on mobile networks.

### New
- `VanduoSectionCache` (new `docs/js/section-cache.js`): in-memory LRU cache (20 entries) backed by `sessionStorage`, consulted by `loadSection` and populated by prefetch + navigation.
- Hover / touch prefetching on sidebar links and global search result rows (`pointerenter`, `touchstart`).
- Idle warm-up of the current tab's remaining sections via `requestIdleCallback` (with `setTimeout` fallback).
- Minimal stale-while-revalidate **service worker** (`docs/sw.js`) scoped to `/sections/**`, versioned, registered only on non-local origins.
- `document.startViewTransition` wraps section swaps when supported.

### Updates
- `AbortController` threaded through `handleRoute` → `switchTab` / `loadSection` / `preloadSectionsBefore`; rapid clicks cancel stale fetches.
- `content-visibility: auto` + `contain-intrinsic-size` on offscreen sections.
- `overflow-anchor: auto` on `#dynamic-content` and a re-anchor pass in `settleDocScrollLoader` to prevent target drift during parallel inserts.
- `<link rel=\"prefetch\">` added for `sections/sections.json`.
- Docs-site `ThemeCustomizer.DEFAULTS` override changed: `neutral = slate`, `radius = 0.5` (from `neutral` / `0.375`). Component page defaults table updated to match.
- Meta version bumped to **v1.3.6** (`package.json`, JSON-LD `softwareVersion`, `<meta>` / OG / Twitter titles). Framework CDN pin left at `@v1.3.5`.

### Files changed
- `docs/package.json`, `docs/index.html`, `docs/sections/changelog.html` — version bump + v1.3.6 changelog entry
- `docs/js/app.js`, `docs/css/app.css` — navigation, caching, prefetching, abort plumbing, content-visibility, anchoring
- `docs/js/section-cache.js` *(new)* — LRU section HTML cache
- `docs/sw.js` *(new)* — stale-while-revalidate service worker for `/sections/**`

### Not included
- `docs/dist/*` rebuild artifacts (from local `sync:framework` run) were intentionally **not** staged — framework is unchanged and a v1.3.6 framework release does not exist yet.

## Test plan
- [ ] Mobile Chrome: open Components, open TOC drawer, tap an item — verify (a) skeleton appears immediately, (b) link shows pressed state, (c) section scrolls into view without visual jump.
- [ ] Mobile Chrome: open global search, type a query, tap a result deep inside Components/Guides — verify fast arrival (preceding sections stream in parallel) and correct scroll position.
- [ ] Desktop Chrome: hover sidebar link, then click — second click should feel instant (cache hit).
- [ ] Rapid-click two different sidebar items — second click should win; first fetch should abort (check DevTools Network).
- [ ] Reload after navigating into a section — `sessionStorage` cache should repopulate; navigation should be instant.
- [ ] Production origin only: verify `sw.js` registers and caches `/sections/*.html`; verify offline-after-visit still serves cached section HTML.
- [ ] Regression: theme customizer now defaults to slate / 0.5; theme-customizer component docs table matches.

No merge yet — leaving this open for review.

Made with [Cursor](https://cursor.com)