### PR TITLE
fix(docs): pin scroll anchor on backfill + make parallax demo legible

### DIFF
--- a/js/modules/doc-navigation.js
+++ b/js/modules/doc-navigation.js
@@ -122,6 +122,42 @@ export function markProgrammaticScroll() {
 }
 
 /**
+ * Keep an anchor element pinned at a captured viewport position across the
+ * frames following a DOM mutation. A single post-mutation measurement is
+ * unreliable: an injected section can keep growing for a frame or two after it
+ * loads (web fonts, responsive grids, demo init). Measuring the anchor's new
+ * position too early under-compensates and drops the reader far from where they
+ * were. This re-pins each frame until the anchor holds still for a few frames,
+ * with a frame cap as a safety valve.
+ * @param {HTMLElement} anchorEl - element whose viewport position to preserve.
+ * @param {number} anchorTop - the getBoundingClientRect().top to hold it at.
+ */
+function pinScrollAnchor(anchorEl, anchorTop) {
+    if (!anchorEl || anchorTop == null) return;
+    var stableFrames = 0;
+    var frameCount = 0;
+    function step() {
+        if (!anchorEl.isConnected) return;
+        var delta = anchorEl.getBoundingClientRect().top - anchorTop;
+        if (Math.abs(delta) > 0.5) {
+            markProgrammaticScroll();
+            window.scrollTo({
+                top: (window.scrollY || window.pageYOffset || 0) + delta,
+                behavior: 'instant'
+            });
+            stableFrames = 0;
+        } else {
+            stableFrames += 1;
+        }
+        frameCount += 1;
+        if (stableFrames < 3 && frameCount < 30) {
+            window.requestAnimationFrame(step);
+        }
+    }
+    step();
+}
+
+/**
  * Abort any in-flight settlement loop. Increments the generation counter so
  * the rAF loop exits, and releases the pending navigation lock. Does NOT
  * clear docExplicitNavSectionId / docExplicitNavCooldownUntil.
@@ -1094,15 +1130,7 @@ export async function loadPreviousSection(options = {}) {
         });
 
         if (anchorEl && anchorEl.isConnected && anchorTop != null) {
-            var nextTop = anchorEl.getBoundingClientRect().top;
-            var delta = nextTop - anchorTop;
-            if (Math.abs(delta) > 1) {
-                markProgrammaticScroll();
-                window.scrollTo({
-                    top: (window.scrollY || window.pageYOffset || 0) + delta,
-                    behavior: 'instant'
-                });
-            }
+            pinScrollAnchor(anchorEl, anchorTop);
         }
 
         requestActiveDocSectionUpdate();

--- a/sections/effects/parallax.html
+++ b/sections/effects/parallax.html
@@ -11,11 +11,62 @@
         #parallax .parallax-demo {
             border-radius: var(--vd-card-border-radius, 0.5rem);
             border: 1px solid var(--vd-border-color);
+            /* Named timeline tracking this panel's travel through the viewport.
+               Defined here (not via view() on the layer) because the layer lives
+               inside .vd-parallax's overflow:hidden box, which would otherwise be
+               treated as its scrollport. */
+            view-timeline-name: --pd-panel;
+            view-timeline-axis: block;
         }
-        #parallax .parallax-demo .vd-parallax-bg {
-            background: linear-gradient(135deg,
-                color-mix(in srgb, var(--vd-color-primary) 45%, var(--vd-bg-secondary)),
-                color-mix(in srgb, var(--vd-color-info) 45%, var(--vd-bg-secondary)));
+        /* Oversize the moving layers so their (now larger) drift never reveals
+           the container edge as they translate. */
+        #parallax .parallax-demo .vd-parallax-bg,
+        #parallax .parallax-demo .vd-parallax-layer {
+            top: -30%;
+            height: 160%;
+        }
+        /* Far layer — a tall multi-stop colour band. It drifts slowly with the
+           parallax transform, and its visible colours shift as the panel travels
+           through the viewport (scroll-driven; see the @supports block below). */
+        #parallax .parallax-demo .pd-layer-back {
+            background: linear-gradient(150deg,
+                var(--vd-color-primary) 0%,
+                var(--vd-color-info) 35%,
+                var(--vd-color-success, var(--vd-color-info)) 50%,
+                var(--vd-color-info) 65%,
+                var(--vd-color-primary) 100%);
+            background-size: 100% 260%;
+            background-position: 50% 0%;
+        }
+        /* Near layer — a dot grid that drifts much faster, so the depth reads clearly. */
+        #parallax .parallax-demo .pd-layer-dots {
+            background-image: radial-gradient(
+                color-mix(in srgb, var(--vd-text-on-primary, #fff) 70%, transparent) 2.5px, transparent 2.5px);
+            background-size: 30px 30px;
+            opacity: 0.6;
+        }
+        /* Scroll-driven colour shift on the far layer (progressive enhancement —
+           browsers without scroll timelines simply keep the static gradient). */
+        @keyframes pd-colour-drift {
+            from { background-position: 50% 0%; }
+            to   { background-position: 50% 100%; }
+        }
+        @supports (animation-timeline: view()) {
+            #parallax .parallax-demo .pd-layer-back {
+                /* Longhands on purpose: the `animation` shorthand resets
+                   animation-duration to 0s, which parks a scroll-driven
+                   animation at a fixed progress. `auto` maps it to the timeline. */
+                animation-name: pd-colour-drift;
+                animation-duration: auto;
+                animation-timing-function: linear;
+                animation-fill-mode: both;
+                animation-timeline: --pd-panel;
+            }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            #parallax .parallax-demo .pd-layer-back {
+                animation-name: none;
+            }
         }
         #parallax .parallax-demo .vd-parallax-content {
             display: flex;
@@ -26,7 +77,10 @@
             text-align: center;
             color: var(--vd-text-on-primary, #fff);
             font-weight: 600;
-            text-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+            text-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+        }
+        #parallax .parallax-demo .vd-parallax-content i {
+            margin-right: 0.4rem;
         }
     </style>
 
@@ -35,16 +89,21 @@
         <div class="vd-col-12">
             <div class="vd-card vd-card-glow demo-card">
                 <div class="vd-card-header">
-                    <h6>Background Layer</h6>
+                    <h6>Depth from layered speeds</h6>
                 </div>
                 <div class="vd-card-body">
-                    <p class="vd-mb-5">Scroll the page — the gradient layer drifts slower than the
-                        foreground content. <code>.vd-parallax-bg</code> moves at the container speed;
-                        the content stays put.</p>
-                    <div class="vd-parallax vd-parallax-sm vd-parallax-slow parallax-demo">
-                        <div class="vd-parallax-bg"></div>
+                    <p class="vd-mb-5">Scroll the page — the colour band
+                        (<code>.vd-parallax-bg</code>, slow) and the dot grid
+                        (<code>.vd-parallax-layer</code>, fast) translate at different rates via
+                        <code>data-parallax-speed</code>, while the foreground
+                        <code>.vd-parallax-content</code> stays put. That difference in rates is what
+                        reads as depth. The colour band also shifts as the panel scrolls through the
+                        viewport — a CSS scroll-driven flourish layered on top.</p>
+                    <div class="vd-parallax vd-parallax-md vd-parallax-fast parallax-demo">
+                        <div class="vd-parallax-bg pd-layer-back" data-parallax-speed="0.4"></div>
+                        <div class="vd-parallax-layer pd-layer-dots" data-parallax-speed="1.5"></div>
                         <div class="vd-parallax-content">
-                            <span>Scroll to see the layer drift</span>
+                            <span><i class="ph ph-arrows-down-up"></i>Scroll — the colour band shifts as the dot grid races ahead</span>
                         </div>
                     </div>
                     <p class="vd-text-sm vd-text-muted vd-mt-5"><strong>Reduced motion:</strong> if


### PR DESCRIPTION
Scroll anchor (loadPreviousSection): a single post-prepend measurement captured the prepended section's height a frame too early (morph measured at 648px before it reflowed to 2200px), under-compensating and dropping the reader ~1550px into the previous section when scrolling up from the last section (parallax). Re-pin the anchor each frame via pinScrollAnchor until it holds still, so late layout growth (fonts, grids, demo init) is absorbed instead of yanking the viewport.

Parallax demo: the single slow gradient drifted only ~15px over a long scroll — imperceptible. Use two patterned layers at clearly different data-parallax-speed rates (dot grid races ahead of the colour band), oversize them so drift never reveals the container edge, and add a scroll-driven colour shift via a named view-timeline (progressive enhancement; falls back to a static gradient and respects reduced-motion).